### PR TITLE
fix: use public repository url for mender-mcu-client submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "components/mender-mcu-client/mender-mcu-client"]
 	path = components/mender-mcu-client/mender-mcu-client
-	url = git@github.com:joelguittet/mender-mcu-client.git
+	url = https://github.com/joelguittet/mender-mcu-client


### PR DESCRIPTION
The current url uses ssh access to github, which is only available if you have previously set it up. Switching to https will make the set up work for everybody, including anonymous users.

Signed-off-by: Josef Holzmayr <jester@theyoctojester.info>