### PR TITLE
client: update following cleaning of config

### DIFF
--- a/main/main.c
+++ b/main/main.c
@@ -267,10 +267,10 @@ app_main(void) {
     mender_client_config_t    mender_client_config    = { .mac_address                  = mac_address,
                                                     .artifact_name                = artifact_name,
                                                     .device_type                  = device_type,
-                                                    .host                         = CONFIG_MENDER_SERVER_HOST,
-                                                    .tenant_token                 = CONFIG_MENDER_SERVER_TENANT_TOKEN,
-                                                    .authentication_poll_interval = CONFIG_MENDER_CLIENT_AUTHENTICATION_POLL_INTERVAL,
-                                                    .update_poll_interval         = CONFIG_MENDER_CLIENT_UPDATE_POLL_INTERVAL,
+                                                    .host                         = NULL,
+                                                    .tenant_token                 = NULL,
+                                                    .authentication_poll_interval = 0,
+                                                    .update_poll_interval         = 0,
                                                     .recommissioning              = false };
     mender_client_callbacks_t mender_client_callbacks = { .authentication_success = authentication_success_cb,
                                                           .authentication_failure = authentication_failure_cb,
@@ -286,7 +286,7 @@ app_main(void) {
 
     /* Initialize mender add-ons */
 #ifdef CONFIG_MENDER_CLIENT_ADD_ON_CONFIGURE
-    mender_configure_config_t    mender_configure_config    = { .refresh_interval = CONFIG_MENDER_CLIENT_CONFIGURE_REFRESH_INTERVAL };
+    mender_configure_config_t    mender_configure_config    = { .refresh_interval = 0 };
     mender_configure_callbacks_t mender_configure_callbacks = {
 #ifndef CONFIG_MENDER_CLIENT_CONFIGURE_STORAGE
         .config_updated = config_updated,
@@ -296,7 +296,7 @@ app_main(void) {
     ESP_LOGI(TAG, "Mender configure initialized");
 #endif /* CONFIG_MENDER_CLIENT_ADD_ON_CONFIGURE */
 #ifdef CONFIG_MENDER_CLIENT_ADD_ON_INVENTORY
-    mender_inventory_config_t mender_inventory_config = { .refresh_interval = CONFIG_MENDER_CLIENT_INVENTORY_REFRESH_INTERVAL };
+    mender_inventory_config_t mender_inventory_config = { .refresh_interval = 0 };
     ESP_ERROR_CHECK(mender_inventory_init(&mender_inventory_config));
     ESP_LOGI(TAG, "Mender inventory initialized");
 #endif /* CONFIG_MENDER_CLIENT_ADD_ON_INVENTORY */


### PR DESCRIPTION
The purpose of this Pull Request is to update the example following the cleaning of config usage on mender-mcu-client.
Now a NULL config is used to use the default value from the client library. It is possible to override the configuration at runtime to use a specific host, token, or period, etc.