### PR TITLE
Add troubleshoot file transfer support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 .vscode
 build
 dependencies.lock
-main/idf_component.yml
 managed_components
 sdkconfig
 sdkconfig.ci

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ You may want to customize few interesting settings:
 
 Other settings are available in the Kconfig. You can also refer to the mender-mcu-client API and configuration keys.
 
-Particularly, it is possible to activate the Device Troubleshoot add-on that will permit to display the logs of the ESP32 directly on the Mender interface as shown on the following screenshot.
+Particularly, it is possible to activate the Device Troubleshoot add-on that will permit to display the logs of the ESP32 directly on the Mender interface as shown on the following screenshot. File Transfer feature can be activated too. A littlefs partition is used to upload/download files to/from the Mender server.
 
 ![Troubleshoot console](https://raw.githubusercontent.com/joelguittet/mender-esp32-example/master/.github/docs/troubleshoot.png)
 
@@ -181,6 +181,12 @@ Congratulation! You have updated the device. Mender server displays the success 
 
 In case of failure to connect and authenticate to the server the current example application performs a rollback to the previous release.
 You can customize the behavior of the example application to add your own checks and perform the rollback in case the tests fail.
+
+### Using Device Troubleshoot add-on
+
+The Device Troubleshoot add-on permits to display the Zephyr Shell on the Mender interface. Autocompletion and colors are available.
+
+The Device Troubleshoot add-on also permits to upload/download files to/from the Mender server. The littlefs partition mounted at `/littlefs` is used to demonstrate this feature. To send a file to the device, destination path must start with `/littlefs`. To download a file from the device the full path is expected, starting with `/littlefs`.
 
 ### Using an other ESP32 module
 

--- a/main/idf_component.yml
+++ b/main/idf_component.yml
@@ -1,0 +1,20 @@
+# @file      idf_component.yml
+# @brief     mender-esp32-example main component dependencies
+#
+# Copyright joelguittet and mender-mcu-client contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+dependencies:
+  espressif/esp_websocket_client: "~=1.2.3"
+  joltwallet/littlefs: "~=1.14.2"

--- a/partitions.csv
+++ b/partitions.csv
@@ -2,5 +2,6 @@
 nvs,      data, nvs,      ,        32K,
 otadata,  data, ota,      ,        8K,
 phy_init, data, phy,      ,        4K,
-ota_0,    app,  ota_0,    ,        1984K,
-ota_1,    app,  ota_1,    ,        1984K,
+ota_0,    app,  ota_0,    ,        1728K,
+ota_1,    app,  ota_1,    ,        1728K,
+storage,  data, littlefs, ,        512K,


### PR DESCRIPTION
The purpose of this Pull-Request is to add troubleshoot file transfer support to the mender-esp32-example project.

A LittleFS partition is added to send/receive files from the mender-server. The mount path of this partition is /littlefs.