### PR TITLE
Check connected flag before reconnecting

### DIFF
--- a/main/main.c
+++ b/main/main.c
@@ -782,7 +782,7 @@ app_main(void) {
                 /* Reconnection requested while not disconnected yet */
                 xEventGroupSetBits(mender_client_events, MENDER_CLIENT_EVENT_CONNECTED);
                 ESP_LOGI(TAG, "Connected to the network");
-            } else {
+            } else if (connected) {
                 /* Disconnect the network */
                 ESP_LOGI(TAG, "Disconnecting network");
                 if (ESP_OK != example_disconnect()) {
@@ -791,6 +791,8 @@ app_main(void) {
                     connected = false;
                     ESP_LOGI(TAG, "Disconnected of the network");
                 }
+            } else {
+                ESP_LOGW(TAG, "Already disconnected of the network");
             }
         }
         if (MENDER_CLIENT_EVENT_RESTART == (events & MENDER_CLIENT_EVENT_RESTART)) {

--- a/main/main.c
+++ b/main/main.c
@@ -766,13 +766,18 @@ app_main(void) {
         EventBits_t events = xEventGroupWaitBits(
             mender_client_events, MENDER_CLIENT_EVENT_CONNECT | MENDER_CLIENT_EVENT_DISCONNECT | MENDER_CLIENT_EVENT_RESTART, pdTRUE, pdFALSE, portMAX_DELAY);
         if (MENDER_CLIENT_EVENT_CONNECT == (events & MENDER_CLIENT_EVENT_CONNECT)) {
-            /* Connect to the network */
-            ESP_LOGI(TAG, "Connecting to the network");
-            if (ESP_OK != example_connect()) {
-                xEventGroupSetBits(mender_client_events, MENDER_CLIENT_EVENT_DISCONNECTED);
-                ESP_LOGE(TAG, "Unable to connect network");
+            if (!connected) {
+                /* Connect to the network */
+                ESP_LOGI(TAG, "Connecting to the network");
+                if (ESP_OK != example_connect()) {
+                    xEventGroupSetBits(mender_client_events, MENDER_CLIENT_EVENT_DISCONNECTED);
+                    ESP_LOGE(TAG, "Unable to connect network");
+                } else {
+                    connected = true;
+                    xEventGroupSetBits(mender_client_events, MENDER_CLIENT_EVENT_CONNECTED);
+                    ESP_LOGI(TAG, "Connected to the network");
+                }
             } else {
-                connected = true;
                 xEventGroupSetBits(mender_client_events, MENDER_CLIENT_EVENT_CONNECTED);
                 ESP_LOGI(TAG, "Connected to the network");
             }


### PR DESCRIPTION
Without this check, the example_connect may receive spurious calls.